### PR TITLE
Feat: restrict API access to frontend url only

### DIFF
--- a/app/Http/Middleware/RestrictToFrontendDomain.php
+++ b/app/Http/Middleware/RestrictToFrontendDomain.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RestrictToFrontendDomain
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (app()->environment('local', 'development')) {
+            return $next($request);
+        }
+
+        $allowedDomain = env('ALLOWED_ORIGIN');
+
+        $origin = $request->headers->get('Origin');
+        $referer = $request->headers->get('Referer');
+
+        if (
+            ($origin && parse_url($origin, PHP_URL_HOST) !== $allowedDomain) &&
+            ($referer && parse_url($referer, PHP_URL_HOST) !== $allowedDomain)
+        ) {
+            return response()->json(['errors' => 'Forbidden'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,7 +13,7 @@ return Application::configure(basePath: dirname(__DIR__))
         apiPrefix: ''
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        \App\Http\Middleware\RestrictToFrontendDomain::class;
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/config/cors.php
+++ b/config/cors.php
@@ -19,7 +19,9 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => ['*'],
+    'allowed_origins' => env('APP_ENV') === 'production'
+        ? [env('ALLOWED_ORIGIN')]
+        : ['*'],
 
     'allowed_origins_patterns' => [],
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\KomnewsController;
 use App\Http\Controllers\MegaprokerController;
 use App\Http\Controllers\ResearchController;
 use App\Http\Controllers\SyntaxController;
+use App\Http\Middleware\RestrictToFrontendDomain;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -15,27 +16,28 @@ Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
 
-//community
-Route::get('/communities', [CommunityController::class, 'index']);
-Route::get('/communities/{slug}', [CommunityController::class, 'showBySlug']);
+Route::middleware([RestrictToFrontendDomain::class])->group(function () { //community
+    Route::get('/communities', [CommunityController::class, 'index']);
+    Route::get('/communities/{slug}', [CommunityController::class, 'showBySlug']);
 
-//division
-Route::get("/divisions", [DivisionController::class, 'index']);
-Route::get("/divisions/{slug}", [DivisionController::class, 'show']);
+    //division
+    Route::get("/divisions", [DivisionController::class, 'index']);
+    Route::get("/divisions/{slug}", [DivisionController::class, 'show']);
 
-// iGallery
-Route::get("/igalleries", [IGalleryController::class, 'index']);
-Route::get("/igalleries/subjects", [IGallerySubjectController::class, 'index']);
+    // iGallery
+    Route::get("/igalleries", [IGalleryController::class, 'index']);
+    Route::get("/igalleries/subjects", [IGallerySubjectController::class, 'index']);
 
-// Komnews
-Route::get('/komnews', [KomnewsController::class, 'index']);
-Route::get('/komnews/{slug}', [KomnewsController::class, 'showBySlug']);
+    // Komnews
+    Route::get('/komnews', [KomnewsController::class, 'index']);
+    Route::get('/komnews/{slug}', [KomnewsController::class, 'showBySlug']);
 
-// Megaproker
-Route::get('/megaprokers', [MegaprokerController::class, 'index']);
+    // Megaproker
+    Route::get('/megaprokers', [MegaprokerController::class, 'index']);
 
-// Research
-Route::get("/research", [ResearchController::class, "index"]);
+    // Research
+    Route::get("/research", [ResearchController::class, "index"]);
 
-// Syntax
-Route::get("/syntaxes", [SyntaxController::class, "index"]);
+    // Syntax
+    Route::get("/syntaxes", [SyntaxController::class, "index"]);
+});


### PR DESCRIPTION
In procuction, by checking ALLOWED_ORIGIN in .env file. This middleware can restrict to only the ALLOWED_ORIGIN by checking its Origin and Referer.