### PR TITLE
Fix: Komnews image attachment

### DIFF
--- a/app/Models/Komnews.php
+++ b/app/Models/Komnews.php
@@ -39,6 +39,21 @@ class Komnews extends Model
 
         static::deleting(function ($news) {
             Storage::disk('public')->delete($news->image);
+
+            $doc = new \DOMDocument();
+            libxml_use_internal_errors(true);
+            $doc->loadHTML($news->content);
+
+            $images = $doc->getElementsByTagName('img');
+
+            foreach ($images as $img) {
+                $src = $img->getAttribute('src');
+
+                $relativePath = str_replace(url('/storage'), '', $src);
+
+                Storage::disk('public')->delete($relativePath);
+            }
+            libxml_clear_errors();
         });
 
         static::updating(function ($news) {

--- a/database/migrations/2025_04_11_135410_change_content_column_type_in_komnews.php
+++ b/database/migrations/2025_04_11_135410_change_content_column_type_in_komnews.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('komnews', function (Blueprint $table) {
+            $table->longText('content')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('komnews', function (Blueprint $table) {
+            $table->string('content')->change();
+        });
+    }
+};


### PR DESCRIPTION
Fix :The current komnews content field is defined as a string in the migration file, which limits the content to 255 characters. To support longer entries, this should be updated to use the text or longText data type.

Fix: Filament's RichEditor supports image attachments within the content. However, when a komnews entry is deleted, the associated images in content field remain in storage, leading to orphaned files. A cleanup mechanism should be implemented to automatically delete these images when their corresponding content is removed.