### PR TITLE
Fix: cant access ALLOWED_ORIGIN after executing 'php artisan config:cache' in production

### DIFF
--- a/app/Http/Middleware/RestrictToFrontendDomain.php
+++ b/app/Http/Middleware/RestrictToFrontendDomain.php
@@ -19,7 +19,7 @@ class RestrictToFrontendDomain
             return $next($request);
         }
 
-        $allowedDomain = env('ALLOWED_ORIGIN');
+        $allowedDomain = config('app.allowed_origin');
         $allowedDomain = parse_url($allowedDomain, PHP_URL_HOST);
 
         $origin = $request->headers->get('Origin');

--- a/config/app.php
+++ b/config/app.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-
+    'allowed_origin' => env('ALLOWED_ORIGIN', '*'),
     /*
     |--------------------------------------------------------------------------
     | Application Name


### PR DESCRIPTION
In a Laravel production environment, executing php artisan config:cache compiles all configuration files into a single cached file. As a result, any usage of env() outside of the configuration files will return null, since Laravel no longer loads .env values at runtime.

To ensure environment-dependent values like ALLOWED_ORIGIN remain accessible after caching, it's best practice to expose them via a configuration file (e.g., config/app.php or a custom config such as config/cors.php). This approach ensures consistent and reliable access to these values through the config() helper, even after configuration caching is enabled.