### PR TITLE
Performance(komnews, communities) : optimize endpoints

### DIFF
--- a/app/Http/Controllers/CommunityController.php
+++ b/app/Http/Controllers/CommunityController.php
@@ -15,7 +15,7 @@ class CommunityController extends Controller
      */
     public function index(): JsonResponse
     {
-        $communities = Community::select('name', 'slug', 'logo')->get();
+        $communities = Community::select('name', 'slug', 'logo', 'description')->get();
         return response()->json([
             'communities' => $communities
         ]);

--- a/app/Http/Controllers/KomnewsController.php
+++ b/app/Http/Controllers/KomnewsController.php
@@ -28,6 +28,24 @@ class KomnewsController extends Controller
         ]);
     }
 
+    // For homepage, limit to 5 komnews
+    public function indexHome(): JsonResponse
+    {
+        $today = Carbon::today(config("app.timezone"));
+        $komnews = Komnews::whereDate('created_at', '!=', $today)
+            ->orderBy('created_at', 'desc')
+            ->take(5)
+            ->get();
+        $todayHeadlines = Komnews::whereDate('created_at', $today)
+            ->orderBy('created_at', 'desc')
+            ->take(5)
+            ->get();
+        return response()->json([
+            'komnews' => $komnews,
+            'todayHeadlines' => $todayHeadlines
+        ]);
+    }
+
     public function showBySlug(String $slug): JsonResponse
     {
         try {

--- a/app/Http/Controllers/KomnewsController.php
+++ b/app/Http/Controllers/KomnewsController.php
@@ -32,6 +32,7 @@ class KomnewsController extends Controller
     public function indexHome(): JsonResponse
     {
         $today = Carbon::today(config("app.timezone"));
+        $categories = KomnewsCategory::all(["name", "slug"]);
         $komnews = Komnews::whereDate('created_at', '!=', $today)
             ->orderBy('created_at', 'desc')
             ->take(5)
@@ -41,6 +42,7 @@ class KomnewsController extends Controller
             ->take(5)
             ->get();
         return response()->json([
+            'categories' => $categories,
             'komnews' => $komnews,
             'todayHeadlines' => $todayHeadlines
         ]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -33,6 +33,7 @@ Route::middleware([RestrictToFrontendDomain::class])->group(function () {
 
     // Komnews
     Route::get('/komnews', [KomnewsController::class, 'index']);
+    Route::get('/komnews/home', [KomnewsController::class, 'indexHome']);
     Route::get('/komnews/{slug}', [KomnewsController::class, 'showBySlug']);
 
     // Megaproker


### PR DESCRIPTION
- /komnews/home :  takes only 5 komnews, prevent overfetching in homepage
- /communities : add description so in homepage, client didnt need to fetch individual community endpoint to get the description

why not pagination? because it have different API structures so the change will break.
But pagination is in the backlog and future feature soon